### PR TITLE
Fix for removing snmp-server host commstring

### DIFF
--- a/aruba.pm
+++ b/aruba.pm
@@ -590,7 +590,7 @@ sub WriteTerm {
 				ProcessHistory("","","","$1 <removed>\n") && next;
 
 			/^(snmp-server host (\d+\.\d+\.\d+\.\d+) version [1-3]c? )\S+(.*)?$/ &&
-				ProcessHistory("SNMPSERVERHOST","ipsort","$2","!$1<removed>$2\n") && next;
+				ProcessHistory("SNMPSERVERHOST","ipsort","$2","!$1<removed>$3\n") && next;
 		} else {
 			/^snmp-server host (\d+\.\d+\.\d+\.\d+)/ &&
 				ProcessHistory("SNMPSERVERHOST","ipsort","$1","$_") && next;


### PR DESCRIPTION
Found a bug where the snmp community string wasn't being re-written properly, due to wrong brackets being selected in the match.
